### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/ezxmlm.opam
+++ b/ezxmlm.opam
@@ -9,7 +9,7 @@ doc: "https://mirage.github.io/ezxmlm/"
 dev-repo: "git+https://github.com/mirage/ezxmlm.git"
 depends: [
   "ocaml" {>= "4.02.3"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "xmlm" {>= "1.1.0"}
 ]
 build: [


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.